### PR TITLE
Update setup.py for python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(
     description="Whatsappy is a Python library for creating whatsapp bots.",
     packages=["whatsappy"],
     classifiers=[
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
         "Operating System :: OS Independent",
     ],
@@ -22,6 +21,7 @@ setup(
         "webdriver-manager ~= 3.2.2",
         "opencv-python ~= 4.5.1.48",
     ],
+    python_require=">3.10",
     extra_requires={
         "dev": [
             "pytest>=3.7",


### PR DESCRIPTION
Since the `match` statement is being used in the codebase and it was introducted in Python 3.10, I think we add python 3.10 as the minimum required version.
Merging this would prevent errors like the one in https://github.com/italoseara/whatsappy/issues/12

I don't know how to test this, though, so I don't want to merge it myself right now.
@italoseara can you take a look at this?